### PR TITLE
"turtle light v2" removed from the hash test.

### DIFF
--- a/tests/hash/main.cpp
+++ b/tests/hash/main.cpp
@@ -53,7 +53,6 @@ typedef crypto::hash chash;
     HASH_X_MACRO(extra_skein,     "extra-skein") \
     HASH_X_MACRO(heavy_v1,        "heavy-v1") \
     HASH_X_MACRO(heavy_v2,        "heavy-v2") \
-    HASH_X_MACRO(turtle_light_v2, "turtle-light-v2") \
     HASH_X_MACRO(count,           "INVALID_COUNT")
 
 #define HASH_X_MACRO(hash_type, str) hash_type,
@@ -157,8 +156,7 @@ int main(int argc, char *argv[]) {
       case hash_type::extra_skein:     hash_extra_skein  (buf, len, actual_byte_ptr); break;
       case hash_type::heavy_v1:        cn_slow_hash      (buf, len, actual, cn_slow_hash_type::heavy_v1); break;
       case hash_type::heavy_v2:        cn_slow_hash      (buf, len, actual, cn_slow_hash_type::heavy_v2); break;
-      case hash_type::turtle_light_v2: cn_slow_hash      (buf, len, actual, cn_slow_hash_type::turtle_lite_v2); break;
-
+      
       default:
       {
         cerr << "Unknown hashing function" << endl;


### PR DESCRIPTION
This commit removes turtle_light_v2 from tests.

Reason: this macro causes a build error at least on debian.

**IMPORTANT NOTE:** If you use turtle_light_v2 hashing algo anywhere - discard this commit.